### PR TITLE
More Pointed, Copointed instances

### DIFF
--- a/pointed.cabal
+++ b/pointed.cabal
@@ -27,11 +27,13 @@ library
     containers           >= 0.4     && < 0.6,
     comonad              >= 4       && < 5,
     data-default-class   >= 0.0.1   && < 0.1,
+    hashable             >= 1.1     && < 1.3,
     kan-extensions       >= 4.2     && < 5,
     semigroups           >= 0.8.3.1 && < 1,
     semigroupoids        >= 4       && < 5,
     stm                  >= 2.1.2.1 && < 2.5,
-    tagged               >= 0.5     && < 1
+    tagged               >= 0.5     && < 1,
+    unordered-containers >= 0.2     && < 0.3
 
   exposed-modules:
     Data.Pointed

--- a/src/Data/Pointed.hs
+++ b/src/Data/Pointed.hs
@@ -7,6 +7,7 @@ module Data.Pointed where
 
 import Control.Arrow
 import Control.Applicative
+import Control.Comonad
 import Control.Concurrent.STM
 import Data.Default.Class
 import qualified Data.Monoid as Monoid
@@ -15,8 +16,14 @@ import Data.Functor.Identity
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Tree (Tree(..))
+import Data.Hashable
+import Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Functor.Bind
 import Data.Functor.Constant
 import Data.Functor.Kan.Rift
 import qualified Data.Functor.Product as Functor
@@ -123,6 +130,23 @@ instance Pointed Semigroup.Max where
 instance Pointed Semigroup.Min where
   point = Semigroup.Min
 
+instance Pointed Option where
+  point = Option . Just
+
+instance Pointed WrappedMonoid where
+  point = WrapMonoid
+
+#if MIN_VERSION_semigroups(0,16,2)
+instance Default a => Pointed (Arg a) where
+  point = Arg def
+#endif
+
+instance (Default k, Hashable k) => Pointed (HashMap k) where
+  point = HashMap.singleton def
+
+instance Default k => Pointed (Map k) where
+  point = Map.singleton def
+
 instance Pointed Seq where
   point = Seq.singleton
 
@@ -192,3 +216,12 @@ instance Pointed m => Pointed (Strict.StateT s m) where
 
 instance Pointed m => Pointed (Static m a) where
   point = Static . point . const
+
+instance Pointed (Cokleisli w a) where
+  point = Cokleisli . const
+
+instance Pointed f => Pointed (WrappedApplicative f) where
+  point = WrapApplicative . point
+
+instance Pointed (MaybeApply f) where
+  point = MaybeApply . Right

--- a/src/Data/Pointed.hs
+++ b/src/Data/Pointed.hs
@@ -13,7 +13,7 @@ import Data.Default.Class
 import qualified Data.Monoid as Monoid
 import Data.Semigroup as Semigroup
 import Data.Functor.Identity
-import Data.Sequence (Seq)
+import Data.Sequence (Seq, ViewL(..), ViewR(..))
 import qualified Data.Sequence as Seq
 import Data.Tree (Tree(..))
 import Data.Hashable
@@ -149,6 +149,12 @@ instance Default k => Pointed (Map k) where
 
 instance Pointed Seq where
   point = Seq.singleton
+
+instance Pointed ViewL where
+  point a = a :< Seq.empty
+
+instance Pointed ViewR where
+  point a = Seq.empty :> a
 
 instance Pointed Set where
   point = Set.singleton


### PR DESCRIPTION
I added several `Pointed` and `Copointed` instances I'd like to have in the library, namely:

From `base`:
* `Copointed m => Copointed (WrappedMonad m)`

From `comonad`:
* `Pointed (Cokleiskli w a)`

From `containers`:
* `Default k => Pointed (Map k)`
* `Pointed ViewL`
* `Pointed ViewR`

From `unordered-containers`:
* `(Default k, Hashable k) => Pointed (HashMap k)`

From `semigroups`:
* `Pointed (Option a)`
* `Default a => Pointed (Arg a)`
* `Copointed (Arg a)`
* `Pointed WrappedMonoid`
* `Copointed WrappedMonoid`

From `semigroupoids`:
* `Pointed f => Pointed (WrappedApplicative f)`
* `Copointed f => Copointed (WrappedApplicative f)`
* `Pointed f => Pointed (MaybeApply f)`
* `Copointed f => Copointed (MaybeApply f)`

From `transformers`:
* `Copointed f => Copointed (Backwards f)`
* `Copointed f => Copointed (Lift f)`
* `Copointed f => Copointed (Reverse f)`