### PR TITLE
Fix disabling the comonad flag

### DIFF
--- a/src/Data/Copointed.hs
+++ b/src/Data/Copointed.hs
@@ -92,9 +92,11 @@ instance Copointed w => Copointed (StoreT s w) where
   copoint (StoreT wf s) = copoint wf s
 #endif
 
-#if defined(MIN_VERSION_comonad) && !(MIN_VERSION_comonad(4,3,0))
+#ifdef MIN_VERSION_comonad
+#if !(MIN_VERSION_comonad(4,3,0))
 instance (Copointed p, Copointed q) => Copointed (Coproduct p q) where
   copoint = coproduct copoint copoint
+#endif
 #endif
 
 #ifdef MIN_VERSION_containers


### PR DESCRIPTION
When building with the `comonad` flag disabled, I was getting the error

```
src/Data/Copointed.hs:95:0:
     error: missing binary operator before token "("
     #if defined(MIN_VERSION_comonad) && !(MIN_VERSION_comonad(4,3,0))
```

I'm not sure exactly what the C preprocessor doesn't like about that.
It seems fairly reasonable to me.  This commit just splits the
conditional in a way that seems to work.  The split conditional
construct is used elsewhere, though, so maybe someone else encountered
the same problem in the past.